### PR TITLE
Prototype change to Either return type [WIP]

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/summary/polygonal/PolygonalSummary.scala
+++ b/raster/src/main/scala/geotrellis/raster/summary/polygonal/PolygonalSummary.scala
@@ -21,6 +21,9 @@ import geotrellis.raster.rasterize.Rasterizer
 import geotrellis.util.{GetComponent, MethodExtensions}
 import spire.syntax.cfor._
 
+/** WARNING: This is currently a WIP API that will not be stable
+  * until the general geotrellis 3.0.0 release.
+  */
 object PolygonalSummary {
   final val DefaultOptions =
     Rasterizer.Options(includePartial = true, sampleType = PixelIsArea)

--- a/raster/src/main/scala/geotrellis/raster/summary/polygonal/PolygonalSummaryResult.scala
+++ b/raster/src/main/scala/geotrellis/raster/summary/polygonal/PolygonalSummaryResult.scala
@@ -1,6 +1,0 @@
-package geotrellis.raster.summary.polygonal
-
-sealed trait PolygonalSummaryResult[+A]
-
-case object NoIntersection extends PolygonalSummaryResult[Nothing]
-case class Summary[A](value: A) extends PolygonalSummaryResult[A]

--- a/raster/src/test/scala/geotrellis/raster/summary/polygonal/HistogramSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/summary/polygonal/HistogramSpec.scala
@@ -41,11 +41,7 @@ class HistogramSpec
 
     it("computes Int Histogram for Singleband") {
       val result = rs.polygonalSummary(zone, FastMapHistogramVisitor)
-
-      result match {
-        case Summary(histogram) => histogram.itemCount(1) should equal(40)
-        case _                  => fail("polygonalSummary did not return a result")
-      }
+      result.right.get.itemCount(1) should equal(40)
     }
 
 //    it("computes Histogram for Multiband") {
@@ -59,14 +55,9 @@ class HistogramSpec
 
     it("computes double Histogram for Singleband") {
       val result = rs.polygonalSummary(zone, StreamingHistogramVisitor)
-
-      result match {
-        case Summary(histogram) => {
-          histogram.itemCount(1) should equal(40)
-          histogram.itemCount(2) should equal(0)
-        }
-        case _ => fail("polygonalSummary did not return a result")
-      }
+      val histogram = result.right.get
+      histogram.itemCount(1) should equal(40)
+      histogram.itemCount(2) should equal(0)
     }
 
 //    it("computes double Histogram for Multiband") {

--- a/raster/src/test/scala/geotrellis/raster/summary/polygonal/MaxSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/summary/polygonal/MaxSpec.scala
@@ -16,6 +16,7 @@
 
 package geotrellis.raster.summary.polygonal
 
+import cats.implicits._
 import geotrellis.raster._
 import geotrellis.raster.summary.visitors.MaxVisitor
 import geotrellis.vector._
@@ -63,39 +64,33 @@ class MaxSpec
 
     it("computes Maximum for Singleband") {
       val result = rs.polygonalSummary(zone, MaxVisitor)
-      result should equal(Summary(Some(1)))
+      result.right.get should equal(Some(1))
     }
 
     it("computes NoIntersection for disjoint Singleband polygon") {
       val disjointZone = Extent(50, 50, 60, 60).toPolygon
       val result = rs.polygonalSummary(disjointZone, MaxVisitor)
 
-      result should equal(NoIntersection)
+      result.left.get should equal(NoIntersectionException())
     }
 
     it("computes None for Singleband NODATA") {
       val result = nodataRS.polygonalSummary(zone, MaxVisitor)
-      result should equal(Summary(None))
+      result.right.get should equal(None)
     }
 
     it("computes Maximum for Multiband") {
       val result = multibandRaster
         .polygonalSummary(zone, MaxVisitor)
 
-      result match {
-        case Summary(results) => results.foreach { _ should equal(Some(1)) }
-        case _ => fail("polygonalSummary did not return a result")
-      }
+      result.right.get.foreach { _ should equal(Some(1)) }
     }
 
     it("computes None for Multiband NODATA") {
       val result = multibandNoDataRaster
         .polygonalSummary(zone, MaxVisitor)
 
-      result match {
-        case Summary(results) => results.foreach { _ should equal(None) }
-        case _ => fail("polygonalSummary did not return a result")
-      }
+      result.right.get.foreach { _ should equal(None) }
     }
 
 //    it("computes Double Maximum for Singleband") {


### PR DESCRIPTION
## Overview

I'm not sure there's a big world of difference here. For the two use cases we have in demo code, Either works better because we're already in an Either chain:
- https://github.com/geotrellis/geotrellis-usbuildings/blob/master/src/main/scala/usbuildings/BuildingsApp.scala#L57
- https://github.com/echeipesh/geotrellis-wri-workshop/blob/master/src/main/scala/org/globalforestwatch/treecoverloss/TreeLossRDD.scala#L94

But there's zero guarantee that generalizes well. Tests are a bit cleaner since there's no failure ADT case to handle. 

It's likely that if we stuck with the ADT, we could provide an implicit toEither conversion since our ADT currently only has two possible values and therefore handle both since there aren't really any other types that we could return here.

Philosophically, NoIntersection is a valid result, not an Exception, so I'm still a bit wary of this Either implementation. I think having seen both, _I'd be inclined to stick with the ADT version and add a toEither and/or toOption implicit conversion for those that might need it._

Compare with the open changes available at: 
- [PolygonalSummary class](https://github.com/locationtech/geotrellis/pull/2920/files#diff-b30754c65e88f0739a22b9fb952b3fa2R53)
- [PolygonalSummaryResult](https://github.com/locationtech/geotrellis/pull/2920/files#diff-9063085c733282ef38c78fd84bce2838R3)
- [Some tests](https://github.com/locationtech/geotrellis/pull/2920/files#diff-81c938b228e0fe442ec96b9389a168edR78)
